### PR TITLE
Issue #4: Error getting current schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>3.3.2</version>
+			<version>3.5.3</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/liquibase/ext/redshift/database/RedshiftDatabase.java
+++ b/src/main/java/liquibase/ext/redshift/database/RedshiftDatabase.java
@@ -3,6 +3,8 @@ package liquibase.ext.redshift.database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
 import liquibase.util.StringUtils;
 
 import java.util.Arrays;
@@ -194,4 +196,10 @@ public class RedshiftDatabase extends PostgresDatabase {
     public String getCurrentDateTimeFunction() {
         return "GETDATE()";
     }
+    
+    @Override
+    protected SqlStatement getConnectionSchemaNameCallStatement() {
+        return new RawSqlStatement("select current_schema()");
+    }
+
 }

--- a/src/test/java/liquibase/ext/redshift/database/RedshiftDatabaseTest.java
+++ b/src/test/java/liquibase/ext/redshift/database/RedshiftDatabaseTest.java
@@ -4,10 +4,23 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
+
 public class RedshiftDatabaseTest {
 
     @Test
     public void testGetShortName() throws Exception {
         assertEquals("redshift", new RedshiftDatabase().getShortName());
     }
+    
+    @Test
+    public void testGetConnectionSchemaNameCallStatement() throws Exception {
+        
+        SqlStatement sqlStatement = new RedshiftDatabase().getConnectionSchemaNameCallStatement();
+        
+        assertEquals(RawSqlStatement.class, sqlStatement.getClass());
+        assertEquals("select current_schema()", ((RawSqlStatement)sqlStatement).getSql());
+    }
+
 }


### PR DESCRIPTION
- fixed the issue by providing a correct SqlStatement to get the schema name

additionally
- upgraded liquibase dependency to 3.5.3
- refactored package folder structure to avoid issues with some java compilers