### PR TITLE
Fix for invalid database selection

### DIFF
--- a/src/main/java/liquibase/ext/redshift/database/RedshiftDatabase.java
+++ b/src/main/java/liquibase/ext/redshift/database/RedshiftDatabase.java
@@ -15,6 +15,8 @@ import java.util.Set;
 
 public class RedshiftDatabase extends PostgresDatabase {
 
+    private static final int HIGH_PRIORITY = 5;
+
     private Set<String> redshiftReservedWords = new HashSet<String>();
 
     public RedshiftDatabase() {
@@ -182,6 +184,11 @@ public class RedshiftDatabase extends PostgresDatabase {
     @Override
     protected String getDefaultDatabaseProductName() {
         return "Redshift";
+    }
+
+    @Override
+    public int getPriority() {
+        return HIGH_PRIORITY;
     }
 
     @Override


### PR DESCRIPTION
Fix for issue mentioned in #4 (Error setting up or running Liquibase: java.sql.SQLException: [Amazon](500310) Invalid operation: syntax error at or near "TAG";)
RedshiftDatabase or PostgresDatabase were randomly selected because they were stored in HashMap.
Higher priority prefers Redshift over Postgres. 