### PR TITLE
DAT-16080  DevOps :: Extension Nightly Builds Failing

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.0
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.1
     secrets: inherit
 

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,14 @@
+# This workflow will build the extension against the latest Liquibase artifact
+name: "Nightly build"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 1-5'
+
+jobs:
+    nightly-build:
+      uses: liquibase/build-logic/.github/workflows/oss-extension-test.yml@v0.5.1
+      with:
+        nightly: true
+      secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.0
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.1
     secrets: inherit
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.0
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.1
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,12 +88,12 @@ jobs:
 
   sonar-pr:
     needs: [ unit-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.5.0
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.5.1
     secrets: inherit
 
   dependabot:
     needs: unit-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.0
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.1
     secrets: inherit
 
 #  prepare-database:


### PR DESCRIPTION
chore(workflows): update liquibase/build-logic workflows to latest versions
- Update attach-artifact-release.yml to use v0.5.1 of extension-attach-artifact-release.yml
- Add build-nightly.yml workflow with v0.5.1 of oss-extension-test.yml
- Update create-release.yml to use v0.5.1 of create-release.yml
- Update release-published.yml to use v0.5.1 of extension-release-published.yml
- Update test.yml to use v0.5.1 of sonar-pull-request.yml and dependabot-automerge.yml