### PR TITLE
chore(workflows): update liquibase/build-logic workflows to v0.5.8

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.8
     secrets: inherit
 

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.7
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
       with:
         nightly: true
         extraMavenArgs: -Dtest="RedshiftDatabaseTest"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.8
     secrets: inherit
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.8
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   build-test:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
     secrets: inherit
     with:
       extraMavenArgs: -Dtest="RedshiftDatabaseTest"
 
   dependabot-automerge:
     needs: build-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.8
     secrets: inherit


### PR DESCRIPTION
The liquibase/build-logic workflows have been updated to version v0.5.8. This update includes bug fixes and improvements to the workflows. By updating to the latest version, we ensure that we are using the most stable and up-to-date version of the workflows.