### PR TITLE
🔧 update actions/upload download-artifact version to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: liquibase-redshift-artifacts
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: Archive Redshift Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: redshift-test-results
           path: build/spock-reports


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/test.yml` file to use newer versions of GitHub Actions for downloading and uploading artifacts.

* Updated `actions/download-artifact` from version 3 to version 4 (`.github/workflows/test.yml`)
* Updated `actions/upload-artifact` from version 3 to version 4 (`.github/workflows/test.yml`)