### PR TITLE
DAT-19298 DevOps :: Refactor test.yml to use ephemeral RedShift infra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,9 @@ jobs:
           --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
-          --url="${{ env.REDSHIFT_URL }}?ssl=false" dropAll 
+          --url="${{ env.REDSHIFT_URL }}?ssl=false" \
+          --hono-system-views=false --disable-database-locking=true \
+           dropAll 
 
       - name: Init Database
         run: | 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,10 +65,10 @@ jobs:
           pip install localstack awscli-local
 
           # Install Docker and start the service
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-          sudo service docker start
-
+          apt-get update
+          apt-get install -y docker.io
+          service docker start
+          
           # Pull the required LocalStack Pro image
           docker pull localstack/localstack-pro
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
-          --url="${{ env.REDSHIFT_URL }}/ssl=false" dropAll 
+          --url="${{ env.REDSHIFT_URL }}?ssl=false" dropAll 
 
       - name: Init Database
         run: | 
@@ -139,7 +139,7 @@ jobs:
           --changeLogFile="harness.initScript.sql" \
            --username="${{ env.TH_REDSHIFT_USER }}" \
            --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
-           --url="${{ env.REDSHIFT_URL }}/ssl=false" update
+           --url="${{ env.REDSHIFT_URL }}?ssl=false" update
 
   # integration-test:
   #   name: Test Harness for Redshift ${{ matrix.redshift }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
 
   destroy-ephemeral-cloud-infra:
     if: always()
-    needs: [ deploy-ephemeral-cloud-infra, prepare-database ]
+    needs: [ deploy-ephemeral-cloud-infra, prepare-database, integration-test ]
     uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
       - synchronize
 
 jobs:
-
   authorize:
     environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
@@ -25,7 +24,7 @@ jobs:
 
   prepare-database:
     name: Clean and initialize database
-    # needs: build-test
+    needs: build-test
     runs-on: ubuntu-latest
     # container:
     #   image: liquibase/liquibase:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - run: true
 
-  # build-test:
-  #   needs: authorize
-  #   uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
-  #   secrets: inherit
-  #   with:
-  #     extraMavenArgs: -Dtest="RedshiftDatabaseTest"
+  build-test:
+    needs: authorize
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+    secrets: inherit
+    with:
+      extraMavenArgs: -Dtest="RedshiftDatabaseTest"
 
   prepare-database:
     name: Clean and initialize database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-redshift-artifacts
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           name: liquibase-redshift-artifacts
     
+      - name: Extract Liquibase Redshift Artifacts version
+        run: |
+          version=$(ls liquibase-redshift*.pom | cut -d '-' -f3)
+          echo "Liquibase Redshift Artifacts version: $version"
+          echo "lb_redshift_jar=liquibase-redshift-$version-SNAPSHOT.jar" >> $GITHUB_ENV
+
       - name: Install liquibase
         run: |
           wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
@@ -55,8 +61,8 @@ jobs:
       - name: Add Redshift extension and driver to liquibase classpath
         run: |
           cp redshift-jdbc42-2.1.0.14.jar src/test/resources/
-          cp liquibase-redshift-*-SNAPSHOT.jar src/test/resources/
-
+          cp ${{ env.lb_redshift_jar }} src/test/resources/
+ 
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
         with:
@@ -122,14 +128,14 @@ jobs:
       - name: Clean AWS Redshift Database
         run: |
           liquibase --username="${{ env.TH_REDSHIFT_USER }}" \
-          --classpath="src/test/resources" \
+          --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
           --url="${{ env.REDSHIFT_URL }}" dropAll 
 
       - name: Init Database
         run: | 
-          liquibase --classpath="src/test/resources" \
+          liquibase --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --changeLogFile="harness.initScript.sql" \
            --username="${{ env.TH_REDSHIFT_USER }}" \
            --password="${{ env.TH_REDSHIFT_PASSWORD }}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,10 @@ jobs:
     name: Clean and initialize database
     # needs: build-test
     runs-on: ubuntu-latest
-    container:
-      image: liquibase/liquibase:latest
-
+    # container:
+    #   image: liquibase/liquibase:latest
+    env:
+      LPM_VERSION: 0.2.3
     strategy:
       fail-fast: false
 
@@ -56,6 +57,16 @@ jobs:
         with:
           python-version: '3.11.5'
 
+      - name: Install liquibase and lpm
+        run: |
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+          sudo apt-get update
+          sudo apt-get install liquibase
+          curl -L -o lpm-${{ env.LPM_VERSION }}-linux.zip https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip
+          sudo unzip -o lpm-${{ env.LPM_VERSION }}-linux.zip -d /usr/bin
+            
       - name: Start & Configure LocalStack
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
@@ -63,11 +74,6 @@ jobs:
         run: |
           # Install LocalStack and supporting tools
           pip install localstack awscli-local
-
-          # Install Docker and start the service
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-          sudo service docker start
 
           # Pull the required LocalStack Pro image
           docker pull localstack/localstack-pro

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,12 +122,18 @@ jobs:
       - name: Clean AWS Redshift Database
         run: |
           liquibase --username="${{ env.TH_REDSHIFT_USER }}" \
+          --classpath="src/test/resources" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
           --url="${{ env.REDSHIFT_URL }}" dropAll 
 
       - name: Init Database
-        run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="${{ env.TH_REDSHIFT_USER }}" --password="${{ env.TH_REDSHIFT_PASSWORD }}" --url="${{ env.REDSHIFT_URL }}" update
+        run: | 
+          liquibase --classpath="src/test/resources" \
+          --changeLogFile="harness.initScript.sql" \
+           --username="${{ env.TH_REDSHIFT_USER }}" \
+           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
+           --url="${{ env.REDSHIFT_URL }}" update
 
   # integration-test:
   #   name: Test Harness for Redshift ${{ matrix.redshift }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
     name: Clean and initialize database
     needs: build-test
     runs-on: ubuntu-latest
-    # container:
-    #   image: liquibase/liquibase:latest
+    container:
+      image: liquibase/liquibase:latest
     env:
       LPM_VERSION: 0.2.3
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
-          --url="${{ env.REDSHIFT_URL }}" dropAll 
+          --url="${{ env.REDSHIFT_URL }}/ssl=false" dropAll 
 
       - name: Init Database
         run: | 
@@ -139,7 +139,7 @@ jobs:
           --changeLogFile="harness.initScript.sql" \
            --username="${{ env.TH_REDSHIFT_USER }}" \
            --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
-           --url="${{ env.REDSHIFT_URL }}" update
+           --url="${{ env.REDSHIFT_URL }}/ssl=false" update
 
   # integration-test:
   #   name: Test Harness for Redshift ${{ matrix.redshift }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,10 @@ jobs:
       #     sudo apt-get install liquibase
       #     curl -L -o lpm-${{ env.LPM_VERSION }}-linux.zip https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip
       #     sudo unzip -o lpm-${{ env.LPM_VERSION }}-linux.zip -d /usr/bin
-            
+           
+      - name: Set up Docker Buildx
+        uses: docker/setup-docker-action@v4
+
       - name: Start & Configure LocalStack
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,14 @@ jobs:
           echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
           sudo apt-get update
           sudo apt-get install liquibase
-
+          
       # FIXME the redshift jar version should come from the pom.xml file
       - name: Download AWS Redshift driver
         run: wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
 
       - name: Add Redshift extension and driver to liquibase classpath
         run: |
+          mkdir -p /liquibase/lib
           cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
           cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,10 +124,14 @@ jobs:
 
           echo "Redshift cluster setup complete."
           echo "Redshift URL: $REDSHIFT_URL"
-            
+
+      - name: Veirfy Redshift
+        run: |
+          aws redshift describe-clusters --endpoint-url=${REDSHIFT_ENDPOINT}
+          
       - name: Clean AWS Redshift Database
         run: |
-          liquibase --username="${{ env.TH_REDSHIFT_USER }}" \
+          liquibase --logLevel=DEBUG --username="${{ env.TH_REDSHIFT_USER }}" \
           --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,12 +124,6 @@ jobs:
 
           echo "Redshift cluster setup complete."
           echo "Redshift URL: $REDSHIFT_URL"
-
-      - name: Veirfy Redshift
-        run: |
-          awslocal redshift list-clusters
-
-          aws redshift describe-clusters --endpoint-url=${REDSHIFT_ENDPOINT}
           
       - name: Clean AWS Redshift Database
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,15 +56,15 @@ jobs:
         with:
           python-version: '3.11.5'
 
-      - name: Install liquibase and lpm
-        run: |
-          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-          sudo apt-get update
-          sudo apt-get install liquibase
-          curl -L -o lpm-${{ env.LPM_VERSION }}-linux.zip https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip
-          sudo unzip -o lpm-${{ env.LPM_VERSION }}-linux.zip -d /usr/bin
+      # - name: Install liquibase and lpm
+      #   run: |
+      #     wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+      #     cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+      #     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+      #     sudo apt-get update
+      #     sudo apt-get install liquibase
+      #     curl -L -o lpm-${{ env.LPM_VERSION }}-linux.zip https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip
+      #     sudo unzip -o lpm-${{ env.LPM_VERSION }}-linux.zip -d /usr/bin
             
       - name: Start & Configure LocalStack
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,8 @@ jobs:
            
       - name: Set up Docker Buildx
         uses: docker/setup-docker-action@v4
+        with:
+          version: '20.10' 
 
       - name: Start & Configure LocalStack
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          TH_REDSHIFT_PASSWORD: ${{ secrets.TH_REDSHIFT_PASSWORD }}
         run: |
           # Install LocalStack and supporting tools
           pip install localstack awscli-local
@@ -87,20 +88,20 @@ jobs:
           echo "Startup complete"
 
           # Configure environment variables for Redshift
-          echo "TH_REDSHIFT_CLUSTER=my-redshift-cluster" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_CLUSTER=test-redshift-cluster" >> $GITHUB_ENV
           echo "TH_REDSHIFT_DB=exampledb" >> $GITHUB_ENV
           echo "TH_REDSHIFT_USER=admin" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_PASSWORD=examplePassword123" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_PASSWORD=${{ secrets.TH_REDSHIFT_PASSWORD }}" >> $GITHUB_ENV
           echo "TH_REDSHIFT_PORT=5439" >> $GITHUB_ENV
           echo "TH_REDSHIFT_REGION=us-east-1" >> $GITHUB_ENV
 
           # Set up Redshift cluster in LocalStack
           echo "Creating Redshift cluster in LocalStack..."
           awslocal redshift create-cluster \
-            --cluster-identifier $TH_REDSHIFT_CLUSTER \
-            --db-name $TH_REDSHIFT_DB \
-            --master-username $TH_REDSHIFT_USER \
-            --master-user-password $TH_REDSHIFT_PASSWORD \
+            --cluster-identifier "$TH_REDSHIFT_CLUSTER" \
+            --db-name "$TH_REDSHIFT_DB" \
+            --master-username "$TH_REDSHIFT_USER" \
+            --master-user-password "$TH_REDSHIFT_PASSWORD" \
             --node-type dc2.large \
             --number-of-nodes 2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,11 @@ jobs:
       #     cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
       #     cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
 
+      - name: Setup Python
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: '3.11.5'
+          
       - name: Start & Configure LocalStack
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,8 @@ jobs:
 
       - name: Add Redshift extension and driver to liquibase classpath
         run: |
-          mkdir -p /liquibase/lib
-          cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
-          cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
+          cp redshift-jdbc42-2.1.0.14.jar src/test/resources/
+          cp liquibase-redshift-*-SNAPSHOT.jar src/test/resources/
 
       - name: Setup Python
         uses: actions/setup-python@v5.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
     name: Clean and initialize database
     needs: [ build, deploy-ephemeral-cloud-infra ]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     container:
       image: liquibase/liquibase:latest
 
@@ -79,6 +82,9 @@ jobs:
     name: Test Harness for Redshift ${{ matrix.redshift }}
     needs: [ prepare-database, deploy-ephemeral-cloud-infra ]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,16 @@ jobs:
     with:
       extraMavenArgs: -Dtest="RedshiftDatabaseTest"
 
+  deploy-ephemeral-cloud-infra:
+    uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
+    secrets: inherit
+    with:
+        deploy: true
+        aws_redshift: true
+
   prepare-database:
     name: Clean and initialize database
-    needs: build-test
+    needs: [ build-test , deploy-ephemeral-cloud-infra ]
     runs-on: ubuntu-latest
     env:
       LPM_VERSION: 0.2.3
@@ -67,79 +74,44 @@ jobs:
         uses: actions/setup-python@v5.3.0
         with:
           python-version: '3.11.5'
-           
-      - name: Set up Docker Buildx
-        uses: docker/setup-docker-action@v4
 
-      - name: Start & Configure LocalStack
-        env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-          TH_REDSHIFT_PASSWORD: ${{ secrets.TH_REDSHIFT_PASSWORD }}
-        run: |
-          # Install LocalStack and supporting tools
-          pip install localstack awscli-local
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+            role-to-assume: ${{ secrets.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+            aws-region: us-east-1
 
-          # Pull the required LocalStack Pro image
-          docker pull localstack/localstack-pro
-
-          # Start LocalStack with custom Redshift support
-          DOCKER_FLAGS='-e LOCALSTACK_API_KEY=${{ secrets.LOCALSTACK_API_KEY }}' localstack start -d
-
-          # Wait for LocalStack to fully start
-          echo "Waiting for LocalStack startup..."
-          localstack wait -t 30
-          echo "Startup complete"
-
-          # Configure environment variables for Redshift
-          echo "TH_REDSHIFT_CLUSTER=test-redshift-cluster" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_DB=test_db" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_USER=admin" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_PASSWORD=${{ secrets.TH_REDSHIFT_PASSWORD }}" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_PORT=4510" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_REGION=us-east-1" >> $GITHUB_ENV
-
-      - name: Setup Redshift Cluster
-        run: |  
-          # Set up Redshift cluster in LocalStack
-          echo "Creating Redshift cluster in LocalStack..."
-          awslocal redshift create-cluster \
-            --cluster-identifier ${{ env.TH_REDSHIFT_CLUSTER }} \
-            --db-name ${{ env.TH_REDSHIFT_DB }} \
-            --master-username ${{ env.TH_REDSHIFT_USER }} \
-            --master-user-password ${{ env.TH_REDSHIFT_PASSWORD }} \
-            --node-type dc2.large \
-            --number-of-nodes 2
-
-          # Fetch Redshift cluster endpoint
-          echo "Fetching Redshift cluster endpoint..."
-          REDSHIFT_ENDPOINT=$(awslocal redshift describe-clusters \
-            --cluster-identifier ${{ env.TH_REDSHIFT_CLUSTER }} \
-            --query "Clusters[0].Endpoint.Address" \
-            --output text)
-
-          # Construct Redshift URL
-          REDSHIFT_URL="jdbc:redshift://${REDSHIFT_ENDPOINT}:${{ env.TH_REDSHIFT_PORT }}/${TH_REDSHIFT_DB}"
-          echo "REDSHIFT_URL=${REDSHIFT_URL}" >> $GITHUB_ENV
-
-          echo "Redshift cluster setup complete."
-          echo "Redshift URL: $REDSHIFT_URL"
-          
+      - name: Get TH_REDSHIFT_URL secret
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            REDSHIFT_URL, /testautomation/db_details/aws_redshift_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+      
       - name: Clean AWS Redshift Database
         run: |
-          liquibase --logLevel=DEBUG --username="${{ env.TH_REDSHIFT_USER }}" \
+          liquibase --logLevel=DEBUG --username="${{ env.TH_DB_ADMIN }}" \
           --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
-          --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
+          --password="${{ env.TH_DB_PASSWD }}" \
           --url="${{ env.REDSHIFT_URL }}?ssl=false" dropAll 
 
       - name: Init Database
         run: | 
           liquibase --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --changeLogFile="harness.initScript.sql" \
-           --username="${{ env.TH_REDSHIFT_USER }}" \
-           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
+           --username="${{ env.TH_DB_ADMIN }}" \
+           --password="${{ env.TH_DB_PASSWD }}" \
            --url="${{ env.REDSHIFT_URL }}?ssl=false" update
+
+  destroy-ephemeral-cloud-infra:
+    if: always()
+    needs: [ deploy-ephemeral-cloud-infra, prepare-database ]
+    uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
+    secrets: inherit
+    with:
+        destroy: true
+        stack_id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
+        aws_redshift: true
 
   # integration-test:
   #   name: Test Harness for Redshift ${{ matrix.redshift }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           echo "TH_REDSHIFT_DB=test_db" >> $GITHUB_ENV
           echo "TH_REDSHIFT_USER=admin" >> $GITHUB_ENV
           echo "TH_REDSHIFT_PASSWORD=${{ secrets.TH_REDSHIFT_PASSWORD }}" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_PORT=5439" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_PORT=4510" >> $GITHUB_ENV
           echo "TH_REDSHIFT_REGION=us-east-1" >> $GITHUB_ENV
 
       - name: Setup Redshift Cluster
@@ -127,6 +127,8 @@ jobs:
 
       - name: Veirfy Redshift
         run: |
+          awslocal redshift list-clusters
+
           aws redshift describe-clusters --endpoint-url=${REDSHIFT_ENDPOINT}
           
       - name: Clean AWS Redshift Database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
     name: Clean and initialize database
     needs: build-test
     runs-on: ubuntu-latest
-    container:
-      image: liquibase/liquibase:latest
     env:
       LPM_VERSION: 0.2.3
     strategy:
@@ -41,6 +39,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: liquibase-redshift-artifacts
+    
+      - name: Install liquibase
+        run: |
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+          sudo apt-get update
+          sudo apt-get install liquibase
 
       # FIXME the redshift jar version should come from the pom.xml file
       - name: Download AWS Redshift driver
@@ -58,8 +64,6 @@ jobs:
            
       - name: Set up Docker Buildx
         uses: docker/setup-docker-action@v4
-        with:
-          version: '20.10' 
 
       - name: Start & Configure LocalStack
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: liquibase-redshift-artifacts
 
@@ -55,16 +55,6 @@ jobs:
         uses: actions/setup-python@v5.3.0
         with:
           python-version: '3.11.5'
-
-      # - name: Install liquibase and lpm
-      #   run: |
-      #     wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-      #     cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-      #     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-      #     sudo apt-get update
-      #     sudo apt-get install liquibase
-      #     curl -L -o lpm-${{ env.LPM_VERSION }}-linux.zip https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip
-      #     sudo unzip -o lpm-${{ env.LPM_VERSION }}-linux.zip -d /usr/bin
            
       - name: Set up Docker Buildx
         uses: docker/setup-docker-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - run: true
 
-  build-test:
+  build:
     needs: authorize
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     secrets: inherit
@@ -31,49 +31,30 @@ jobs:
 
   prepare-database:
     name: Clean and initialize database
-    needs: [ build-test , deploy-ephemeral-cloud-infra ]
+    needs: [ build, deploy-ephemeral-cloud-infra ]
     runs-on: ubuntu-latest
-    env:
-      LPM_VERSION: 0.2.3
+    container:
+      image: liquibase/liquibase:latest
+
     strategy:
       fail-fast: false
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           name: liquibase-redshift-artifacts
-    
-      - name: Extract Liquibase Redshift Artifacts version
-        run: |
-          version=$(ls liquibase-redshift*.pom | cut -d '-' -f3)
-          echo "Liquibase Redshift Artifacts version: $version"
-          echo "lb_redshift_jar=liquibase-redshift-$version-SNAPSHOT.jar" >> $GITHUB_ENV
 
-      - name: Install liquibase
-        run: |
-          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-          sudo apt-get update
-          sudo apt-get install liquibase
-          
       # FIXME the redshift jar version should come from the pom.xml file
       - name: Download AWS Redshift driver
         run: wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
 
       - name: Add Redshift extension and driver to liquibase classpath
         run: |
-          cp redshift-jdbc42-2.1.0.14.jar src/test/resources/
-          cp ${{ env.lb_redshift_jar }} src/test/resources/
- 
-      - name: Setup Python
-        uses: actions/setup-python@v5.3.0
-        with:
-          python-version: '3.11.5'
+          cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
+          cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -85,33 +66,76 @@ jobs:
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            REDSHIFT_URL, /testautomation/db_details/aws_redshift_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
-            
+            TH_REDSHIFTURL, /testautomation/db_details/aws_redshift_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+
+      - name: Clean AWS Redshift Database
+        run: liquibase --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ env.TH_REDSHIFTURL }}" dropAll
+
+      - name: Init Database
+        run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ env.TH_REDSHIFTURL }}" update
+
+
+  integration-test:
+    name: Test Harness for Redshift ${{ matrix.redshift }}
+    needs: [ prepare-database, deploy-ephemeral-cloud-infra ]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        redshift: [ "" ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build Cache
+        uses: actions/cache@v3.0.5
+        with:
+          key: build-${{ github.run_number }}-${{ github.run_attempt }}
+          path: |
+            **/target/**
+            ~/.m2/repository/org/liquibase/
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+            role-to-assume: ${{ secrets.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+            aws-region: us-east-1
+
+      - name: Get TH_REDSHIFT_URL secret
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            TH_REDSHIFTURL, /testautomation/db_details/aws_redshift_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+    
+
+      - name: Harness Test Run
+        run: mvn -Dtest="LiquibaseHarnessSuiteIT" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{env.TH_REDSHIFTURL}} test
+
       - name: Foundational Harness Test Run
-        run: mvn -Dtest="LiquibaseHarnessFoundationalSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
+        run: mvn -Dtest="LiquibaseHarnessFoundationalSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{env.TH_REDSHIFTURL}} test
 
       - name: Advanced Harness Test Run
-        run: mvn -Dtest="LiquibaseHarnessAdvancedSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
+        run: mvn -Dtest="LiquibaseHarnessAdvancedSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{env.TH_REDSHIFTURL}} test
 
       - name: Archive Redshift Test Results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
-      
-      - name: Clean AWS Redshift Database
-        run: |
-          liquibase --logLevel=DEBUG --username="${{ env.TH_DB_ADMIN }}" \
-          --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
-          --driver=com.amazon.redshift.jdbc42.Driver \
-          --password="${{ env.TH_DB_PASSWD }}" \
-          --url="${{ env.REDSHIFT_URL }}?ssl=false" dropAll 
+        with:
+          name: redshift-test-results
+          path: build/spock-reports
 
-      - name: Init Database
-        run: | 
-          liquibase --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
-          --changeLogFile="harness.initScript.sql" \
-           --username="${{ env.TH_DB_ADMIN }}" \
-           --password="${{ env.TH_DB_PASSWD }}" \
-           --url="${{ env.REDSHIFT_URL }}?ssl=false" update
+  dependabot-automerge:
+    needs: build
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
+    secrets: inherit
 
   destroy-ephemeral-cloud-infra:
     if: always()
@@ -123,51 +147,3 @@ jobs:
         stack_id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
         aws_redshift: true
 
-  # integration-test:
-  #   name: Test Harness for Redshift ${{ matrix.redshift }}
-  #   needs: prepare-database
-  #   runs-on: ubuntu-latest
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       redshift: [ "" ]
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v3
-  #       with:
-  #         java-version: 11
-  #         distribution: 'temurin'
-  #         cache: 'maven'
-
-  #     - name: Build Cache
-  #       uses: actions/cache@v3.0.5
-  #       with:
-  #         key: build-${{ github.run_number }}-${{ github.run_attempt }}
-  #         path: |
-  #           **/target/**
-  #           ~/.m2/repository/org/liquibase/
-
-  #     - name: Harness Test Run
-  #       run: mvn -Dtest="LiquibaseHarnessSuiteIT" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
-
-  #     - name: Foundational Harness Test Run
-  #       run: mvn -Dtest="LiquibaseHarnessFoundationalSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
-
-  #     - name: Advanced Harness Test Run
-  #       run: mvn -Dtest="LiquibaseHarnessAdvancedSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
-
-  #     - name: Archive Redshift Test Results
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: redshift-test-results
-  #         path: build/spock-reports
-
-  # dependabot-automerge:
-  #   needs: build-test
-  #   uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
-  #   secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,10 +65,10 @@ jobs:
           pip install localstack awscli-local
 
           # Install Docker and start the service
-          apt-get update
-          apt-get install -y docker.io
-          service docker start
-          
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo service docker start
+
           # Pull the required LocalStack Pro image
           docker pull localstack/localstack-pro
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,8 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
       # - name: Download Artifacts
       #   uses: actions/download-artifact@v3
@@ -54,7 +55,7 @@ jobs:
         uses: actions/setup-python@v5.3.0
         with:
           python-version: '3.11.5'
-          
+
       - name: Start & Configure LocalStack
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
@@ -62,6 +63,11 @@ jobs:
         run: |
           # Install LocalStack and supporting tools
           pip install localstack awscli-local
+
+          # Install Docker and start the service
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo service docker start
 
           # Pull the required LocalStack Pro image
           docker pull localstack/localstack-pro

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
   prepare-database:
     name: Clean and initialize database
-    needs: build
+    needs: build-test
     runs-on: ubuntu-latest
     container:
       image: liquibase/liquibase:latest
@@ -50,57 +50,108 @@ jobs:
           cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
           cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
 
+      - name: Start & Configure LocalStack
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          # Install LocalStack and supporting tools
+          pip install localstack awscli-local
+
+          # Pull the required LocalStack Pro image
+          docker pull localstack/localstack-pro
+
+          # Start LocalStack with custom Redshift support
+          DOCKER_FLAGS='-e LOCALSTACK_API_KEY=${{ secrets.LOCALSTACK_API_KEY }}' localstack start -d
+
+          # Wait for LocalStack to fully start
+          echo "Waiting for LocalStack startup..."
+          localstack wait -t 30
+          echo "Startup complete"
+
+          # Configure environment variables for Redshift
+          echo "TH_REDSHIFT_CLUSTER=my-redshift-cluster" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_DB=exampledb" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_USER=admin" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_PASSWORD=examplePassword123" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_PORT=5439" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_REGION=us-east-1" >> $GITHUB_ENV
+
+          # Set up Redshift cluster in LocalStack
+          echo "Creating Redshift cluster in LocalStack..."
+          awslocal redshift create-cluster \
+            --cluster-identifier $TH_REDSHIFT_CLUSTER \
+            --db-name $TH_REDSHIFT_DB \
+            --master-username $TH_REDSHIFT_USER \
+            --master-user-password $TH_REDSHIFT_PASSWORD \
+            --node-type dc2.large \
+            --number-of-nodes 2
+
+          # Fetch Redshift cluster endpoint
+          echo "Fetching Redshift cluster endpoint..."
+          REDSHIFT_ENDPOINT=$(awslocal redshift describe-clusters \
+            --cluster-identifier $TH_REDSHIFT_CLUSTER \
+            --query "Clusters[0].Endpoint.Address" \
+            --output text)
+
+          # Construct Redshift URL
+          REDSHIFT_URL="jdbc:redshift://${REDSHIFT_ENDPOINT}:${TH_REDSHIFT_PORT}/${TH_REDSHIFT_DB}"
+          echo "REDSHIFT_URL=${REDSHIFT_URL}" >> $GITHUB_ENV
+
+          echo "Redshift cluster setup complete."
+          echo "Redshift URL: ${REDSHIFT_URL}"
+            
       - name: Clean AWS Redshift Database
-        run: liquibase --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_REDSHIFTURL }}" dropAll
+        run: liquibase --username="$TH_REDSHIFT_USER" --password="$TH_REDSHIFT_PASSWORD" --url="$REDSHIFT_URL" dropAll
 
       - name: Init Database
-        run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_REDSHIFTURL }}" update
+        run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="$TH_REDSHIFT_USER" --password="$TH_REDSHIFT_PASSWORD" --url="$REDSHIFT_URL" update
 
-  integration-test:
-    name: Test Harness for Redshift ${{ matrix.redshift }}
-    needs: prepare-database
-    runs-on: ubuntu-latest
+  # integration-test:
+  #   name: Test Harness for Redshift ${{ matrix.redshift }}
+  #   needs: prepare-database
+  #   runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        redshift: [ "" ]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       redshift: [ "" ]
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         java-version: 11
+  #         distribution: 'temurin'
+  #         cache: 'maven'
 
-      - name: Build Cache
-        uses: actions/cache@v3.0.5
-        with:
-          key: build-${{ github.run_number }}-${{ github.run_attempt }}
-          path: |
-            **/target/**
-            ~/.m2/repository/org/liquibase/
+  #     - name: Build Cache
+  #       uses: actions/cache@v3.0.5
+  #       with:
+  #         key: build-${{ github.run_number }}-${{ github.run_attempt }}
+  #         path: |
+  #           **/target/**
+  #           ~/.m2/repository/org/liquibase/
 
-      - name: Harness Test Run
-        run: mvn -Dtest="LiquibaseHarnessSuiteIT" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
+  #     - name: Harness Test Run
+  #       run: mvn -Dtest="LiquibaseHarnessSuiteIT" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
 
-      - name: Foundational Harness Test Run
-        run: mvn -Dtest="LiquibaseHarnessFoundationalSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
+  #     - name: Foundational Harness Test Run
+  #       run: mvn -Dtest="LiquibaseHarnessFoundationalSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
 
-      - name: Advanced Harness Test Run
-        run: mvn -Dtest="LiquibaseHarnessAdvancedSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
+  #     - name: Advanced Harness Test Run
+  #       run: mvn -Dtest="LiquibaseHarnessAdvancedSuiteTest" -DdbName=redshift -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl=${{secrets.TH_REDSHIFTURL}} test
 
-      - name: Archive Redshift Test Results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: redshift-test-results
-          path: build/spock-reports
+  #     - name: Archive Redshift Test Results
+  #       if: ${{ always() }}
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: redshift-test-results
+  #         path: build/spock-reports
 
-  dependabot-automerge:
-    needs: build-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
-    secrets: inherit
+  # dependabot-automerge:
+  #   needs: build-test
+  #   uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
+  #   secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,35 +95,37 @@ jobs:
           echo "TH_REDSHIFT_PORT=5439" >> $GITHUB_ENV
           echo "TH_REDSHIFT_REGION=us-east-1" >> $GITHUB_ENV
 
+      - name: Setup Redshift Cluster
+        run: |  
           # Set up Redshift cluster in LocalStack
           echo "Creating Redshift cluster in LocalStack..."
           awslocal redshift create-cluster \
-            --cluster-identifier "$TH_REDSHIFT_CLUSTER" \
-            --db-name "$TH_REDSHIFT_DB" \
-            --master-username "$TH_REDSHIFT_USER" \
-            --master-user-password "$TH_REDSHIFT_PASSWORD" \
+            --cluster-identifier ${{ env.TH_REDSHIFT_CLUSTER }} \
+            --db-name ${{ env.TH_REDSHIFT_DB }} \
+            --master-username ${{ env.TH_REDSHIFT_USER }} \
+            --master-user-password ${{ env.TH_REDSHIFT_PASSWORD }} \
             --node-type dc2.large \
             --number-of-nodes 2
 
           # Fetch Redshift cluster endpoint
           echo "Fetching Redshift cluster endpoint..."
           REDSHIFT_ENDPOINT=$(awslocal redshift describe-clusters \
-            --cluster-identifier $TH_REDSHIFT_CLUSTER \
+            --cluster-identifier ${{ env.TH_REDSHIFT_CLUSTER }} \
             --query "Clusters[0].Endpoint.Address" \
             --output text)
 
           # Construct Redshift URL
-          REDSHIFT_URL="jdbc:redshift://${REDSHIFT_ENDPOINT}:${TH_REDSHIFT_PORT}/${TH_REDSHIFT_DB}"
+          REDSHIFT_URL="jdbc:redshift://${REDSHIFT_ENDPOINT}:${{ env.TH_REDSHIFT_PORT }}/${TH_REDSHIFT_DB}"
           echo "REDSHIFT_URL=${REDSHIFT_URL}" >> $GITHUB_ENV
 
           echo "Redshift cluster setup complete."
-          echo "Redshift URL: ${REDSHIFT_URL}"
+          echo "Redshift URL: $REDSHIFT_URL"
             
       - name: Clean AWS Redshift Database
-        run: liquibase --username="$TH_REDSHIFT_USER" --password="$TH_REDSHIFT_PASSWORD" --url="$REDSHIFT_URL" dropAll
+        run: liquibase --username="${{ env.TH_REDSHIFT_USER }}" --password="${{ env.TH_REDSHIFT_PASSWORD }}" --url="${{ env.REDSHIFT_URL }}" dropAll
 
       - name: Init Database
-        run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="$TH_REDSHIFT_USER" --password="$TH_REDSHIFT_PASSWORD" --url="$REDSHIFT_URL" update
+        run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="${{ env.TH_REDSHIFT_USER }}" --password="${{ env.TH_REDSHIFT_PASSWORD }}" --url="${{ env.REDSHIFT_URL }}" update
 
   # integration-test:
   #   name: Test Harness for Redshift ${{ matrix.redshift }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,19 +36,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: liquibase-redshift-artifacts
+      # - name: Download Artifacts
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: liquibase-redshift-artifacts
 
-      # FIXME the redshift jar version should come from the pom.xml file
-      - name: Download AWS Redshift driver
-        run: wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
+      # # FIXME the redshift jar version should come from the pom.xml file
+      # - name: Download AWS Redshift driver
+      #   run: wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
 
-      - name: Add Redshift extension and driver to liquibase classpath
-        run: |
-          cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
-          cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
+      # - name: Add Redshift extension and driver to liquibase classpath
+      #   run: |
+      #     cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
+      #     cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
 
       - name: Start & Configure LocalStack
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: liquibase-redshift-artifacts
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,19 +38,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # - name: Download Artifacts
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: liquibase-redshift-artifacts
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: liquibase-redshift-artifacts
 
-      # # FIXME the redshift jar version should come from the pom.xml file
-      # - name: Download AWS Redshift driver
-      #   run: wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
+      # FIXME the redshift jar version should come from the pom.xml file
+      - name: Download AWS Redshift driver
+        run: wget https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar
 
-      # - name: Add Redshift extension and driver to liquibase classpath
-      #   run: |
-      #     cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
-      #     cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
+      - name: Add Redshift extension and driver to liquibase classpath
+        run: |
+          cp redshift-jdbc42-2.1.0.14.jar /liquibase/lib/
+          cp liquibase-redshift-*-SNAPSHOT.jar /liquibase/lib/
 
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
@@ -89,7 +89,7 @@ jobs:
 
           # Configure environment variables for Redshift
           echo "TH_REDSHIFT_CLUSTER=test-redshift-cluster" >> $GITHUB_ENV
-          echo "TH_REDSHIFT_DB=exampledb" >> $GITHUB_ENV
+          echo "TH_REDSHIFT_DB=test_db" >> $GITHUB_ENV
           echo "TH_REDSHIFT_USER=admin" >> $GITHUB_ENV
           echo "TH_REDSHIFT_PASSWORD=${{ secrets.TH_REDSHIFT_PASSWORD }}" >> $GITHUB_ENV
           echo "TH_REDSHIFT_PORT=5439" >> $GITHUB_ENV
@@ -122,7 +122,11 @@ jobs:
           echo "Redshift URL: $REDSHIFT_URL"
             
       - name: Clean AWS Redshift Database
-        run: liquibase --username="${{ env.TH_REDSHIFT_USER }}" --password="${{ env.TH_REDSHIFT_PASSWORD }}" --url="${{ env.REDSHIFT_URL }}" dropAll
+        run: |
+          liquibase --username="${{ env.TH_REDSHIFT_USER }}" \
+          --driver=com.amazon.redshift.jdbc42.Driver \
+          --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
+          --url="${{ env.REDSHIFT_URL }}" dropAll 
 
       - name: Init Database
         run: liquibase --classpath="src/test/resources" --changeLogFile="harness.initScript.sql" --username="${{ env.TH_REDSHIFT_USER }}" --password="${{ env.TH_REDSHIFT_PASSWORD }}" --url="${{ env.REDSHIFT_URL }}" update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,9 +131,7 @@ jobs:
           --classpath="src/test/resources/${{ env.lb_redshift_jar }}:src/test/resources/redshift-jdbc42-2.1.0.14.jar" \
           --driver=com.amazon.redshift.jdbc42.Driver \
           --password="${{ env.TH_REDSHIFT_PASSWORD }}" \
-          --url="${{ env.REDSHIFT_URL }}?ssl=false" \
-          --hono-system-views=false --disable-database-locking=true \
-           dropAll 
+          --url="${{ env.REDSHIFT_URL }}?ssl=false" dropAll 
 
       - name: Init Database
         run: | 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - run: true
 
-  build-test:
-    needs: authorize
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
-    secrets: inherit
-    with:
-      extraMavenArgs: -Dtest="RedshiftDatabaseTest"
+  # build-test:
+  #   needs: authorize
+  #   uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+  #   secrets: inherit
+  #   with:
+  #     extraMavenArgs: -Dtest="RedshiftDatabaseTest"
 
   prepare-database:
     name: Clean and initialize database
-    needs: build-test
+    # needs: build-test
     runs-on: ubuntu-latest
     container:
       image: liquibase/liquibase:latest


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow configuration in `.github/workflows/test.yml`. The changes introduce a new job for deploying and destroying ephemeral cloud infrastructure, update existing steps for better dependency management, and improve the setup and initialization processes for testing with AWS Redshift.

Key changes include:

### New Jobs and Workflow Enhancements:
* Added a new job `deploy-ephemeral-cloud-infra` to deploy ephemeral cloud infrastructure using `liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml`.
* Introduced a `destroy-ephemeral-cloud-infra` job to ensure the cleanup of ephemeral cloud infrastructure after the tests are run.

### Dependency Management and Setup:
* Updated the `prepare-database` job to include additional steps for artifact extraction, Liquibase installation, and AWS credential configuration.
* Changed the `actions/checkout` and `actions/download-artifact` to use newer versions (`v4` for checkout and `v4` for download-artifact).

### AWS Redshift Database Initialization:
* Added steps to extract the Liquibase Redshift artifacts version and install Liquibase from a secure source.
* Updated the steps for downloading and setting up the AWS Redshift driver and initializing the database, ensuring the correct classpath and credentials are used.