### PR TITLE
[no-jira] Fix PR CI: exclude junit-platform-suite engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,13 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <!-- Skip junit-platform-suite engine on PR builds: liquibase-test-harness
+                         ships @Suite-annotated classes that need a live Redshift connection,
+                         which the PR workflow does not provision. Harness suites run in the
+                         nightly build instead. -->
+                    <excludeJUnit5Engines>
+                        <exclude>junit-platform-suite</exclude>
+                    </excludeJUnit5Engines>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Summary

PR test runs have been failing across the matrix for over a year (last successful PR run: 2026-05-02). The failure is identical regardless of what the PR changes — every job reports:

```
[ERROR] TestEngine with ID 'junit-platform-suite' failed to discover tests
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.5:test
```

## Root cause

The `liquibase-test-harness` JAR (declared as a `test` dependency) ships three `@Suite`-annotated classes — `BaseHarnessSuite`, `FoundationalHarnessSuite`, `AdvancedHarnessSuite` — whose `@SelectClasses` targets are Spock specs that require a live Redshift connection. The shared `os-extension-test.yml` workflow used by `test.yml` does not provision Redshift, so the JUnit Platform Suite engine aborts discovery and the entire surefire run fails before any unit test executes.

The harness suites are still exercised by the nightly build, which does stand up Redshift.

## Change

Exclude the `junit-platform-suite` engine from surefire in `pom.xml`. The JUnit Vintage engine continues to run `RedshiftDatabaseTest` (the only repo-owned unit test).

## Test plan

- [ ] CI run on this PR completes with all Test Java N jobs green
- [ ] After merge, comment `@dependabot rebase` on the 13 open dependabot PRs and verify they go green