### PR TITLE
[no-jira] Bump junit and junit-platform to 6.0.3 together

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <liquibase.version>5.0.2</liquibase.version>
         <liquibase.sdk.github.token>${env.GITHUB_TOKEN}</liquibase.sdk.github.token>
         <sonar.tests>src/test/groovy</sonar.tests>
-        <junit.version>5.11.4</junit.version>
-        <junit-platform.version>1.11.4</junit-platform.version>
+        <junit.version>6.0.3</junit.version>
+        <junit-platform.version>6.0.3</junit-platform.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Summary

Combines the changes from #362 and #363 into a single bump so the two properties stay aligned.

JUnit 6 unified its version scheme — `junit-jupiter` and `junit-platform` now share major version 6. Bumping either property in isolation creates a mismatch (jupiter 6.x against platform 1.x, or the reverse) that breaks test discovery with:

```
[ERROR] TestEngine with ID 'junit-jupiter' failed to discover tests
```

This single PR bumps:
- `junit.version` 5.11.4 → 6.0.3 (jupiter/vintage engines)
- `junit-platform.version` 1.11.4 → 6.0.3 (platform suite/launcher)

If this goes green, close #362 and #363 in favor of this PR.

## Test plan

- [ ] CI passes on all Java matrix jobs
- [ ] If green: close #362 and #363
- [ ] If still red: leave open for investigation, the failure mode will identify whether other deps (e.g. liquibase-test-harness transitive junit-platform) still cause conflicts