### PR TITLE
INT-2049: Fix RedshiftTagDatabaseGenerator intercepting tag command for non-Redshift databases

### DIFF
--- a/src/main/java/liquibase/ext/redshift/sqlgenerator/core/RedshiftTagDatabaseGenerator.java
+++ b/src/main/java/liquibase/ext/redshift/sqlgenerator/core/RedshiftTagDatabaseGenerator.java
@@ -1,19 +1,15 @@
 package liquibase.ext.redshift.sqlgenerator.core;
 
 import liquibase.database.Database;
-import liquibase.database.core.*;
-import liquibase.sqlgenerator.core.TagDatabaseGenerator;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.ValidationErrors;
+import liquibase.ext.redshift.database.RedshiftDatabase;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
-import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.sqlgenerator.core.TagDatabaseGenerator;
 import liquibase.statement.core.TagDatabaseStatement;
-import liquibase.statement.core.UpdateStatement;
 import liquibase.structure.core.Column;
-import liquibase.structure.core.Table;
-import liquibase.ext.redshift.database.RedshiftDatabase;
 
 public class RedshiftTagDatabaseGenerator extends TagDatabaseGenerator {
 
@@ -25,31 +21,29 @@ public class RedshiftTagDatabaseGenerator extends TagDatabaseGenerator {
     }
 
     @Override
-    public int getPriority()
-    {
-        return 6;
+    public boolean supports(TagDatabaseStatement statement, Database database) {
+        return database instanceof RedshiftDatabase;
+    }
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
     }
 
     @Override
     public Sql[] generateSql(TagDatabaseStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        if (database instanceof RedshiftDatabase) {
-            String tableNameEscaped = database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
-            String orderColumnNameEscaped = database.escapeObjectName("ORDEREXECUTED", Column.class);
-            String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
-            String tagColumnNameEscaped = database.escapeObjectName("TAG", Column.class);
-            String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
+        String tableNameEscaped = database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
+        String orderColumnNameEscaped = database.escapeObjectName("ORDEREXECUTED", Column.class);
+        String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
+        String tagColumnNameEscaped = database.escapeObjectName("TAG", Column.class);
+        String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
 
-            return new Sql[]{
-                    new UnparsedSql(
-                            "UPDATE " + tableNameEscaped + " SET " + tagColumnNameEscaped + " = " + tagEscaped +
-                                    " FROM (SELECT " + dateColumnNameEscaped + ", " + orderColumnNameEscaped + " FROM " + tableNameEscaped + " ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC LIMIT 1) AS sub " +
-                                    "WHERE " + tableNameEscaped + "." + dateColumnNameEscaped + "=sub." + dateColumnNameEscaped + " AND " + tableNameEscaped + "." + orderColumnNameEscaped + "=sub." + orderColumnNameEscaped)
-            };
-        
-        }
-
-
-        return super.generateSql(statement, database, sqlGeneratorChain);
+        return new Sql[]{
+                new UnparsedSql(
+                        "UPDATE " + tableNameEscaped + " SET " + tagColumnNameEscaped + " = " + tagEscaped +
+                                " FROM (SELECT " + dateColumnNameEscaped + ", " + orderColumnNameEscaped + " FROM " + tableNameEscaped + " ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC LIMIT 1) AS sub " +
+                                "WHERE " + tableNameEscaped + "." + dateColumnNameEscaped + "=sub." + dateColumnNameEscaped + " AND " + tableNameEscaped + "." + orderColumnNameEscaped + "=sub." + orderColumnNameEscaped)
+        };
 
     }
 }

--- a/src/test/groovy/liquibase/ext/redshift/sqlgenerator/core/RedshiftTagDatabaseGeneratorTest.groovy
+++ b/src/test/groovy/liquibase/ext/redshift/sqlgenerator/core/RedshiftTagDatabaseGeneratorTest.groovy
@@ -1,0 +1,56 @@
+package liquibase.ext.redshift.sqlgenerator.core
+
+import liquibase.database.core.MSSQLDatabase
+import liquibase.database.core.MySQLDatabase
+import liquibase.database.core.PostgresDatabase
+import liquibase.ext.redshift.database.RedshiftDatabase
+import liquibase.sql.Sql
+import liquibase.sqlgenerator.SqlGenerator
+import liquibase.statement.core.TagDatabaseStatement
+import spock.lang.Specification
+
+class RedshiftTagDatabaseGeneratorTest extends Specification {
+
+    private RedshiftTagDatabaseGenerator generator
+
+    void setup() {
+        generator = new RedshiftTagDatabaseGenerator()
+    }
+
+    def "getPriority returns PRIORITY_DATABASE"() {
+        when:
+        def priority = generator.getPriority()
+
+        then:
+        priority == SqlGenerator.PRIORITY_DATABASE
+    }
+
+    def "supports returns true for RedshiftDatabase and false for non-Redshift databases"() {
+        given:
+        def statement = new TagDatabaseStatement("v1.0")
+
+        expect:
+        generator.supports(statement, new RedshiftDatabase())
+        !generator.supports(statement, new PostgresDatabase())
+        !generator.supports(statement, new MySQLDatabase())
+        !generator.supports(statement, new MSSQLDatabase())
+    }
+
+    def "generateSql produces correct Redshift UPDATE statement"() {
+        given:
+        def database = new RedshiftDatabase()
+        def statement = new TagDatabaseStatement("v1.0")
+        def expectedSql = "UPDATE databasechangelog SET \"TAG\" = 'v1.0'" +
+                " FROM (SELECT DATEEXECUTED, ORDEREXECUTED FROM databasechangelog" +
+                " ORDER BY DATEEXECUTED DESC, ORDEREXECUTED DESC LIMIT 1) AS sub " +
+                "WHERE databasechangelog.DATEEXECUTED=sub.DATEEXECUTED" +
+                " AND databasechangelog.ORDEREXECUTED=sub.ORDEREXECUTED"
+
+        when:
+        Sql[] result = generator.generateSql(statement, database, null)
+
+        then:
+        result.length == 1
+        result[0].toSql() == expectedSql
+    }
+}


### PR DESCRIPTION
`RedshiftTagDatabaseGenerator` did not override `supports()`, so the framework selected it as a generator for `TagDatabaseStatement` on all databases (priority 6 > base priority 5). For non-Redshift databases it delegated to `super.generateSql()`, which produces SQL with a subquery in WHERE - incompatible with CQL (Cassandra), causing tag command to silently succeed without updating the TAG column.

- Added supports() - restricts generator to RedshiftDatabase only
- Changed getPriority() - returns PRIORITY_DATABASE instead of hardcoded 6
- Removed redundant if (database instanceof RedshiftDatabase) guard from generateSql() — guaranteed by supports()