### PR TITLE
ci: split PR build from Dependabot automerge [TECHOPS-1255]

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,16 @@
+name: Dependabot Automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,5 +1,9 @@
 name: Dependabot Automerge
 
+# Separate from test.yml: this workflow never checks out or runs PR code, it only
+# approves and merges Dependabot PRs, so it needs a write-capable token (which the
+# build workflow deliberately does not have). The reusable job is gated to
+# github.event.pull_request.user.login == 'dependabot[bot]'.
 on:
   pull_request_target:
     types:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,31 +2,19 @@ name: Build and Test
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
       - synchronize
-      
+
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   packages: read
   id-token: write
 
 jobs:
-  authorize:
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
   build-test:
-    needs: authorize
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
-    secrets: inherit
-
-  dependabot:
-    needs: build-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
     secrets: inherit


### PR DESCRIPTION
## What

Splits `test.yml's` build/test job onto `pull_request` instead of `pull_request_target`, and moves Dependabot's approve/merge step into its own `dependabot-automerge.yml` on `pull_request_target`.

## Why

Keeps the build job (which compiles and runs PR-supplied code) and the merge job (which needs write access but runs no PR code) on separate, appropriately-scoped triggers. Matches the pattern already applied in [liquibase-parent-pom#849](https://github.com/liquibase/liquibase-parent-pom/pull/849).